### PR TITLE
Enable CORS pre-flight

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,10 +111,12 @@ if (config.oauth2.enable) {
 if (config.oidc.enable) {
   require('./oidc')(server);
 
+  app.options(config.endpoints.certs, require('cors')());
   app.get(config.endpoints.certs, require('cors')(), function(req, res) {
     res.json(keys.jwks);
   });
 
+  app.options(config.endpoints.userinfo, require('cors')());
   app.get(config.endpoints.userinfo, require('cors')(),
       passport.authenticate('bearer', {session:false}),
       function(req, res) {


### PR DESCRIPTION
The `cors` module wasn't being used to respond to OPTIONS.

Thanks to @ayushnvijay, I found out that the CORS didn't work in either Firefox or Safari.
This broke the in-browser version of `oada-id-client`.